### PR TITLE
fix: 修复支付宝小程序无法生成二维码的问题.

### DIFF
--- a/components/tki-qrcode/tki-qrcode.vue
+++ b/components/tki-qrcode/tki-qrcode.vue
@@ -1,7 +1,7 @@
 <template xlang="wxml" minapp="mpvue">
 	<view class="tki-qrcode">
 		<!-- #ifndef MP-ALIPAY -->
-		<canvas class="tki-qrcode-canvas" :canvas-id="cid" :style="{width:cpSize+'px',height:cpSize+'px'}" />
+		<canvas class="tki-qrcode-canvas" :canvas-id="cid" :id="cid" :style="{width:cpSize+'px',height:cpSize+'px'}" />
 		<!-- #endif -->
 		<!-- #ifdef MP-ALIPAY -->
 		<canvas :id="cid" :width="cpSize" :height="cpSize" class="tki-qrcode-canvas" />


### PR DESCRIPTION
支付宝小程序中 `<canvas>` 标签除了 `canvcas-id` 属性之外，还需要添加 `id` 属性，否则 `<canvas>` 无法正确显示。